### PR TITLE
Fixed docstring typo

### DIFF
--- a/ls.py
+++ b/ls.py
@@ -1,4 +1,4 @@
-""" Module that runs the os command """
+""" Module that runs the ls command """
 
 import os
 import shutil


### PR DESCRIPTION
Fixed a typo in the docstring for the ls command - it read os instead of ls